### PR TITLE
Add test config file path to metadata

### DIFF
--- a/enctests/README.md
+++ b/enctests/README.md
@@ -14,7 +14,7 @@ making sure color and quality is preserved.
 
 ## Requirements
 * FFmpeg with VMAF enabled
-* OpenTimelineIO (0.15+ currently only in main) 
+* OpenTimelineIO (>=0.15) 
 
 ## Description
 

--- a/enctests/testframework/encoders/ffmpeg_encoder.py
+++ b/enctests/testframework/encoders/ffmpeg_encoder.py
@@ -71,6 +71,9 @@ class FFmpegEncoder(ABCTestEncoder):
             # !! Use this function from utils to make sure we find the metadata
             # later on
             test_meta = get_test_metadata_dict(mr)
+            test_meta['test_config_path'] = self.test_config.get(
+                'test_config_path'
+            )
             test_meta['encode_arguments'] = wedge
             test_meta['description'] = self.test_config.get('description')
 

--- a/enctests/testframework/main.py
+++ b/enctests/testframework/main.py
@@ -132,12 +132,18 @@ def parse_args():
 
 
 def parse_config_file(path):
-    config_file = path.as_posix()
+    config_file = path.absolute().as_posix()
     with open(config_file, 'rt') as f:
         config = list(yaml.load_all(f, SafeLoader))
 
     test_configs = []
     for test_config in config:
+        # Store path to config file for future reference.
+        test_name = next(iter(test_config))
+        if test_name.startswith('test_'):
+            # Only store config path for tests
+            test_config[test_name]['test_config_path'] = config_file
+
         test_configs.append(test_config)
 
     return test_configs
@@ -443,7 +449,6 @@ def main():
     # Generate any reports (if specified in file)
     if not args.skip_reports:
         processTemplate(test_configs, timeline)
-
 
 
 if __name__== '__main__':


### PR DESCRIPTION
closes #2 

With this PR we store the path to the test config in each media reference's metadata.
I didn't store it "globally" in the timeline's metadata as we may have several test configs and one config doesn't necessarily cover all sources.

The path is stored under the `"test_config_path"` key