### PR TITLE
Relative path support.

### DIFF
--- a/enctests/testframework/encoders/ffmpeg_encoder.py
+++ b/enctests/testframework/encoders/ffmpeg_encoder.py
@@ -71,6 +71,9 @@ class FFmpegEncoder(ABCTestEncoder):
             # !! Use this function from utils to make sure we find the metadata
             # later on
             test_meta = get_test_metadata_dict(mr)
+            test_meta['test_config_path'] = self.test_config.get(
+                'test_config_path'
+            )
             test_meta['encode_arguments'] = wedge
             test_meta['description'] = self.test_config.get('description')
 

--- a/enctests/testframework/main.py
+++ b/enctests/testframework/main.py
@@ -132,12 +132,18 @@ def parse_args():
 
 
 def parse_config_file(path):
-    config_file = path.as_posix()
+    config_file = path.absolute().as_posix()
     with open(config_file, 'rt') as f:
         config = list(yaml.load_all(f, SafeLoader))
 
     test_configs = []
     for test_config in config:
+        # Store path to config file for future reference.
+        test_name = next(iter(test_config))
+        if test_name.startswith('test_'):
+            # Only store config path for tests
+            test_config[test_name]['test_config_path'] = config_file
+
         test_configs.append(test_config)
 
     return test_configs
@@ -443,7 +449,6 @@ def main():
     # Generate any reports (if specified in file)
     if not args.skip_reports:
         processTemplate(test_configs, timeline)
-
 
 
 if __name__== '__main__':

--- a/enctests/testframework/main.py
+++ b/enctests/testframework/main.py
@@ -135,6 +135,7 @@ def parse_config_file(path):
     config_file = path.absolute().as_posix()
     with open(config_file, 'rt') as f:
         config = list(yaml.load_all(f, SafeLoader))
+        config[0]['config_path'] = config_file # Stash where the config file is, useful for reporting and relative paths.
 
     test_configs = []
     for test_config in config:

--- a/enctests/testframework/utils/utils.py
+++ b/enctests/testframework/utils/utils.py
@@ -168,6 +168,9 @@ def get_source_metadata_dict(source_clip):
 
 def create_clip(config):
     path = Path(config.get('path'))
+    if not path.is_absolute():
+        if 'config_path' in config:
+            path = Path(os.path.dirname(config.get("config_path")), path)
 
     clip = otio.schema.Clip(name=path.stem)
     clip.metadata.update({'aswf_enctests': {'source_info': deepcopy(config)}})

--- a/enctests/testframework/utils/utils.py
+++ b/enctests/testframework/utils/utils.py
@@ -170,7 +170,8 @@ def create_clip(config):
     path = Path(config.get('path'))
     if not path.is_absolute():
         if 'config_path' in config:
-            path = Path(os.path.dirname(config.get("config_path")), path)
+            config_path = Path(config.get('config_path'))
+            path = config_path.parent.joinpath(path).resolve()
 
     clip = otio.schema.Clip(name=path.stem)
     clip.metadata.update({'aswf_enctests': {'source_info': deepcopy(config)}})

--- a/sourceimages/chip-chart-1080-noicc.png.yml
+++ b/sourceimages/chip-chart-1080-noicc.png.yml
@@ -1,5 +1,5 @@
 images: false
-path: /test/sourceimages/chip-chart-1080-noicc.png
+path: chip-chart-1080-noicc.png
 width: 1920
 height: 1080
 in: 0


### PR DESCRIPTION
Allow the yml file paths to contain relative paths, so that if we check in paths into github, they will still work.

Signed-off-by: Sam Richards <sam.richards@taurich.org>
