### PR TITLE
Vmaf model fixes

### DIFF
--- a/enctests/runtest.sh
+++ b/enctests/runtest.sh
@@ -1,6 +1,9 @@
 python3 -m testframework.main --source-folder sources/enc_sources --test-config test_configs/prores_tests.yml --output prores-results.otio --encoded-folder prores-encode
+python3 -m testframework.main --source-folder sources/enc_sources --test-config test_configs/prores_qscale_tests.yml --output prores-qscale-results.otio --encoded-folder prores-qscale-encode
 
 python3 -m testframework.otio2html --test-config test_configs/prores_tests.yml --results prores-results.otio
+
+python3 -m testframework.main --source-folder sources/enc_sources --test-config test_configs/codec_tests.yml --output codec-results.otio --encoded-folder codec-encode
 
 python3 -m testframework.main --source-folder sources/enc_sources --test-config test_configs/h264_tests.yml --output h264-results.otio --encoded-folder h264-encode
 
@@ -11,6 +14,38 @@ python3 -m testframework.main --source-folder sources/enc_sources --test-config 
 python3 -m testframework.otio2html --test-config test_configs/h264_crf_tests.yml --results h264-crf-results.otio
 
 python3 -m testframework.main --source-folder sources/enc_sources --test-config test_configs/color_tests.yml --output color-results.otio --encoded-folder color-encode
+python3 -m testframework.main --source-folder sources/enc_sources --test-config test_configs/hevc_color_tests.yml --output hevc-color-results.otio --encoded-folder hevc-color-encode
+
+python3 -m testframework.main --source-folder sources/enc_sources --test-config test_configs/rgb_color_tests.yml --output rgb-color-results.otio --encoded-folder rgb-color-encode
+
+python3 -m testframework.main --source-folder sources/enc_sources --test-config test_configs/rgb_tests.yml --output rgb-results.otio --encoded-folder rgb-encode
+
+python3 -m testframework.main --source-folder sources/enc_sources --test-config test_configs/mjpeg_color_tests.yml --output mjpeg-color-results.otio --encoded-folder mjpeg-color-encode
+
+python3 -m testframework.main --source-folder sources/enc_sources --test-config test_configs/av1_color_tests.yml --output av1-color-results.otio --encoded-folder av1-color-encode
+
+python3 -m testframework.main --source-folder sources/enc_sources --test-config test_configs/vp9_color_tests.yml --output vp9-color-results.otio --encoded-folder vp9-color-encode
+python3 -m testframework.main --source-folder sources/enc_sources --test-config test_configs/vp9_crf_tests.yml --output vp9-crf-results.otio --encoded-folder vp9-crf-encode
+
+python3 -m testframework.main --source-folder sources/enc_sources --test-config test_configs/dnxhd_color_tests.yml --output dnxhd-color-results.otio --encoded-folder dnxhd-color-encode
+python3 -m testframework.main --source-folder sources/enc_sources --test-config test_configs/dnxhd_tests.yml --output dnxhd-results.otio --encoded-folder dnxhd-encode
+
+python3 -m testframework.main --source-folder sources/enc_sources --test-config test_configs/hevc_tests.yml --output hevc-results.otio --encoded-folder hevc-encode
+python3 -m testframework.main --source-folder sources/enc_sources --test-config test_configs/av1_crf_tests.yml --output av1-crf-results.otio --encoded-folder av1-crf-encode
+
+python3 -m testframework.main --source-folder sources/enc_sources --test-config test_configs/hevc_crf_tests.yml --output hevc-crf-results.otio --encoded-folder hevc-crf-encode
+python3 -m testframework.otio2html --test-config test_configs/hevc_crf_tests.yml --results hevc-crf-results.otio
+
+python3 -m testframework.main --source-folder sources/enc_sources --test-config test_configs/color_tests.yml --output color-results.otio --encoded-folder color-encode
+
+# Windows only with nvenc
+python -m testframework.main --source-folder sources/enc_sources --test-config test_configs/hevc_nvenc_color_tests.yml --output hevc-nvenc-color-results.otio --encoded-folder hevc-color-encode
+python -m testframework.main --source-folder sources/enc_sources --test-config test_configs/hevc_nvenc_tests.yml --output hevc-nvenc-results.otio --encoded-folder hevc-nvenc-encode
+python -m testframework.otio2html --test-config test_configs/hevc_nvenc_tests.yml --results hevc-nvenc-results.otio
+
+# OSX Only tests
+python -m testframework.main --source-folder sources/enc_sources --test-config test_configs/osx_prores_tests.yml --output osx-prores-results.otio --encoded-folder osx-prores-encode
+
 
 #WIP
 python3 -m testframework.generatetests

--- a/enctests/testframework/encoders/ffmpeg_encoder.py
+++ b/enctests/testframework/encoders/ffmpeg_encoder.py
@@ -70,7 +70,7 @@ class FFmpegEncoder(ABCTestEncoder):
             # Time encoding process
             t1 = time.perf_counter()
             # Do the encoding
-            log_file = Path(out_file.parent, out_file.stem+".log")
+            log_file = Path(out_file.parent, out_file.stem + ".log")
             with open(log_file, "w") as log_file_object:
                 print(f'ffmpeg command: {cmd}', file=log_file_object)
                 log_file_object.flush()

--- a/enctests/testframework/encoders/ffmpeg_encoder.py
+++ b/enctests/testframework/encoders/ffmpeg_encoder.py
@@ -70,7 +70,7 @@ class FFmpegEncoder(ABCTestEncoder):
             # Time encoding process
             t1 = time.perf_counter()
             # Do the encoding
-            log_file = Path(out_file.parent, out_file.stem).with_suffix(".log")
+            log_file = Path(out_file.parent, out_file.stem+".log")
             with open(log_file, "w") as log_file_object:
                 print(f'ffmpeg command: {cmd}', file=log_file_object)
                 log_file_object.flush()

--- a/enctests/testframework/main.py
+++ b/enctests/testframework/main.py
@@ -602,7 +602,7 @@ def run_tests(args, test_configs, timeline):
                 distorted = Path(test_ref.target_url)
                 print(f"Testing: {distorted.name}")
                 # Send all the log output of the tests to a separate log file.
-                log_file = Path(distorted.parent, distorted.stem+"_tests.log")
+                log_file = Path(distorted.parent, distorted.stem + "_tests.log")
                 with open(log_file, "w") as log_file_object:
                     for test in comparisontests:
                         t1 = time.perf_counter()

--- a/enctests/testframework/main.py
+++ b/enctests/testframework/main.py
@@ -55,6 +55,8 @@ VMAF_LIB_DIR = os.getenv(
     f'{os.path.dirname(__file__)}/../.venv/usr/local/lib/x86_64-linux-gnu'
 )
 
+if not Path(VMAF_LIB_DIR, "model", "vmaf_v0.6.1.json").exists():
+    print(f"WARNING: Cannot find VMAF configuration files at path {VMAF_LIB_DIR}")
 
 def parse_args():
     parser = argparse.ArgumentParser()

--- a/enctests/testframework/main.py
+++ b/enctests/testframework/main.py
@@ -334,7 +334,7 @@ model=path={vmaf_model}\" \
     results = {
         'vmaf': raw_results['pooled_metrics'].get('vmaf'),
         'psnr': raw_results['pooled_metrics'].get('psnr'),   # FFmpeg < 5.1
-        'result': "Completed"
+        'testresult': "Completed"
     }
 
     # TODO Do this as a pretty print.

--- a/enctests/testframework/main.py
+++ b/enctests/testframework/main.py
@@ -602,8 +602,7 @@ def run_tests(args, test_configs, timeline):
                 distorted = Path(test_ref.target_url)
                 print(f"Testing: {distorted.name}")
                 # Send all the log output of the tests to a separate log file.
-                log_file = Path(distorted.parent, distorted.stem+"_tests").with_suffix(".log")
-
+                log_file = Path(distorted.parent, distorted.stem+"_tests.log")
                 with open(log_file, "w") as log_file_object:
                     for test in comparisontests:
                         t1 = time.perf_counter()

--- a/enctests/testframework/utils/utils.py
+++ b/enctests/testframework/utils/utils.py
@@ -13,18 +13,11 @@ VMAF_LIB_DIR = os.getenv(
     f'{os.path.dirname(__file__)}/.venv/usr/local/lib/x86_64-linux-gnu'
 )
 
-
 # Which vmaf model to use
-VMAF_HD_MODEL = os.getenv(
-    'VMAF_MODEL',
-    VMAF_LIB_DIR
-) + "/model/vmaf_v0.6.1.json"
+VMAF_HD_MODEL = Path(VMAF_LIB_DIR, "model", "vmaf_v0.6.1.json")
 
 
-VMAF_4K_MODEL = os.getenv(
-    'VMAF_MODEL',
-    VMAF_LIB_DIR
-) + "/model/vmaf_4k_v0.6.1.json"
+VMAF_4K_MODEL = Path(VMAF_LIB_DIR, "model", "vmaf_4k_v0.6.1.json")
 
 
 # Based on accepted answer here:

--- a/enctests/testframework/utils/utils.py
+++ b/enctests/testframework/utils/utils.py
@@ -17,14 +17,14 @@ VMAF_LIB_DIR = os.getenv(
 # Which vmaf model to use
 VMAF_HD_MODEL = os.getenv(
     'VMAF_MODEL',
-    f'{os.path.dirname(__file__)}/../../tools/vmaf-2.3.1/model/'
-) + "/vmaf_v0.6.1.json"
+    VMAF_LIB_DIR
+) + "/model/vmaf_v0.6.1.json"
 
 
 VMAF_4K_MODEL = os.getenv(
     'VMAF_MODEL',
-    f'{os.path.dirname(__file__)}/../../tools/vmaf-2.3.1/model'
-) + "/vmaf_4k_v0.6.1.json"
+    VMAF_LIB_DIR
+) + "/model/vmaf_4k_v0.6.1.json"
 
 
 # Based on accepted answer here:

--- a/index.md
+++ b/index.md
@@ -48,7 +48,6 @@ You can see the default ffmpeg conversion introduces a dramatic colorshift that 
 	2. [Color Range](ColorPreservation.html#range)
 8. [Web Review](ColorPreservation.html#webreview)
 
-
 ### Acknowledgements  <a name="Acknowledgements"></a>
 
 This document is a result of feedback from many people, in particular I would like to thank Kevin Wheatley, Gates Roberg Clark, Rick Sayre, Wendy Heffner and J Schulte for their time and patience.  


### PR DESCRIPTION
This has a number of fixes, a couple of which are related to simplifying how the VMAF environment directory works.

But there are also a couple of other fixes for path extensions in the tests where we had switched to using .with_suffix which broke the tests, due to there being a period in the filename.