### PR TITLE
Standardize where the test results go, and make summary.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,8 @@ enctests/sources/encsources/chimera_coaster/
 .jekyll-cache/
 enctests/docs-encode/
 enctests/sources/enc_sources/chimera_coaster/
+enctests/old-results
+enctests/sources/enc_sources/chimera_cars_srgb_jpg
+enctests/sources/enc_sources/chimera_wind
+enctests/results.old
+tmp

--- a/enctests/testframework/encoders/__init__.py
+++ b/enctests/testframework/encoders/__init__.py
@@ -1,9 +1,33 @@
 import pathlib
 import opentimelineio as otio
+import platform
 
 from .base import ABCTestEncoder
 from .ffmpeg_encoder import FFmpegEncoder
 
+
+
+encoder_map = {
+    'ffmpeg': FFmpegEncoder
+}
+
+def destination_from_config(
+        test_config: dict,
+        destination: pathlib.Path,
+        results_folder: pathlib.Path
+        ):
+    encoder_cls = encoder_map.get(test_config.get('app'))
+    
+    encoder = encoder_cls(None, test_config, destination)
+
+    if destination == '':
+        # This happens if its not defined, then we change it to be
+        # results/<ENCODERVER>/<APPLICATIONVERSION>/<TEST>-encode
+        app_version = encoder.get_application_version()
+        config_file_base = pathlib.Path(test_config.config_file()).stem
+        destination = results_folder / app_version / f"{platform.system().lower()}-{platform.machine().lower()}" / f"{config_file_base}-encode"
+    test_config.set_destination(destination)
+    return destination
 
 def encoder_factory(
         source_clip: otio.schema.Clip,
@@ -11,10 +35,14 @@ def encoder_factory(
         destination: pathlib.Path
 ) -> ABCTestEncoder:
 
-    encoder_map = {
-        'ffmpeg': FFmpegEncoder
-    }
 
-    encoder = encoder_map.get(test_config.get('app'))
+    encoder_cls = encoder_map.get(test_config.get('app'))
+    
+    encoder = encoder_cls(source_clip, test_config, destination)
 
-    return encoder(source_clip, test_config, destination)
+    encoder.destination = pathlib.Path(destination)
+    print(f"Output directory: {destination}")
+    # Make sure we have a destination folder
+    pathlib.Path(destination).mkdir(parents=True, exist_ok=True)
+
+    return encoder

--- a/enctests/testframework/encoders/ffmpeg_encoder.py
+++ b/enctests/testframework/encoders/ffmpeg_encoder.py
@@ -151,10 +151,10 @@ class FFmpegEncoder(ABCTestEncoder):
         cmd = template.format(
             ffmpeg_bin = FFMPEG_BIN,
             input_args=input_args,
-            source=source_path,
+            source=source_path.as_posix(),
             duration=duration,
             encoding_args=encoding_args,
-            outfile=out_file
+            outfile=out_file.as_posix()
         )
 
         return cmd

--- a/enctests/testframework/encoders/ffmpeg_encoder.py
+++ b/enctests/testframework/encoders/ffmpeg_encoder.py
@@ -95,9 +95,9 @@ class FFmpegEncoder(ABCTestEncoder):
             # !! Use this function from utils to make sure we find the metadata
             # later on
             test_meta = get_test_metadata_dict(mr)
-            test_meta['test_config_path'] = self.test_config.get(
+            test_meta['test_config_path'] = str(self.test_config.get(
                 'test_config_path'
-            )
+            ))
             test_meta['command'] = cmd
             test_meta['encode_arguments'] = wedge
             test_meta['description'] = self.test_config.get('description')

--- a/enctests/testframework/encoders/ffmpeg_encoder.py
+++ b/enctests/testframework/encoders/ffmpeg_encoder.py
@@ -175,7 +175,9 @@ class FFmpegEncoder(ABCTestEncoder):
     def get_output_filename(self, test_name: str) -> pathlib.Path:
         source_path, symbol = self.get_source_path()
         stem = source_path.stem.replace(symbol, '')
-
+        if stem[-1] == ".":
+            stem = stem[:-1]
+    
         out_file = self.destination.absolute().joinpath(
             f"{stem}-{test_name}{self.test_config.get('suffix')}"
         )

--- a/enctests/testframework/generatetests.py
+++ b/enctests/testframework/generatetests.py
@@ -123,12 +123,8 @@ def main():
             else:
                 newtemplate = newtemplate + arg + " "
         
-        #print("Wedge:", wedge)
         template = newtemplate
 
-
-        print("Name:", testname)
-        print("Template:", template)
         if "sources" in test['config']:
             for i in range(0, len(test['config']['sources'])):
                 test['config']['sources'][i] = os.path.abspath(os.path.join(args.root, test['config']['sources'][i]))

--- a/enctests/testframework/main.py
+++ b/enctests/testframework/main.py
@@ -264,6 +264,16 @@ feature="name=psnr":\
 model=path={vmaf_model}\" \
 -f null -\
 '
+
+    if not distorted.exists():
+        results = {'success': False,
+            'testresult': "No movie generated."
+        }
+    
+        enc_meta = get_test_metadata_dict(test_ref)
+        enc_meta['results'].update(results)
+        return
+
     # Get settings from metadata used as basis for encoded media
     source_meta = get_source_metadata_dict(source_clip)
     input_args = ''
@@ -277,7 +287,7 @@ model=path={vmaf_model}\" \
     cmd = vmaf_cmd.format(
         ffmpeg_bin=FFMPEG_BIN,
         reference=reference,
-        distorted=distorted,
+        distorted=distorted.as_posix(),
         duration=source_meta.get('duration'),
         vmaf_model=get_nearest_model(int(source_meta.get('width', 1920)))
     )
@@ -457,7 +467,10 @@ def idiff_compare(source_clip, test_ref, testname, comparisontestinfo, source_pa
     if cmdresult != 0:
         result['result'] = "Unable to extract file for test"
     else:
-        cmd = apptemplate.format(originalfile=sourcepng, newfile=distortedpng, idiff_bin=IDIFF_BIN, newfilediff=diffpng)
+        cmd = apptemplate.format(originalfile=sourcepng, 
+                                 newfile=distortedpng.as_posix(),
+                                idiff_bin=IDIFF_BIN, 
+                                newfilediff=diffpng.as_posix())
         print(f"\n\nIdiff command: {cmd}", file=log_file_object)
         
         output = subprocess.run(shlex.split(cmd), check=False, stdout=subprocess.PIPE).stdout

--- a/enctests/testframework/main.py
+++ b/enctests/testframework/main.py
@@ -286,7 +286,7 @@ model=path={vmaf_model}\" \
 
     cmd = vmaf_cmd.format(
         ffmpeg_bin=FFMPEG_BIN,
-        reference=reference,
+        reference=reference.replace("\\", "/"),
         distorted=distorted.as_posix(),
         duration=source_meta.get('duration'),
         vmaf_model=get_nearest_model(int(source_meta.get('width', 1920)))
@@ -380,7 +380,8 @@ def identity_compare(source_dict, source_clip, test_ref, testname, comparisontes
             'testresult': "No movie generated."
         }
     else:
-        cmd = apptemplate.format(originalfile=compare_movie, newfile=distorted, ffmpeg_bin=FFMPEG_BIN)
+        cmd = apptemplate.format(originalfile=compare_movie, 
+                                 newfile=distorted.as_posix(), ffmpeg_bin=FFMPEG_BIN)
         print(f"\n\identity command: {cmd}", file=log_file_object)
         
         result = subprocess.run(shlex.split(cmd), 

--- a/enctests/testframework/main.py
+++ b/enctests/testframework/main.py
@@ -590,23 +590,23 @@ def run_tests(args, config_data, timeline):
             # Update dict of references
             references.update(results)
 
-        # Add media references to clip
-        source_clip.set_media_references(
-            references, source_clip.DEFAULT_MEDIA_KEY
-        )
+            # Add media references to clip
+            source_clip.set_media_references(
+                references, source_clip.DEFAULT_MEDIA_KEY
+            )
 
-        # Get or create a track to hold test results
-        encoder_version = encoder.get_application_version()
-        track = track_map.setdefault(
-            encoder_version,
-            otio.schema.Track(name=encoder_version)
-        )
+            # Get or create a track to hold test results
+            encoder_version = encoder.get_application_version()
+            track = track_map.setdefault(
+                encoder_version,
+                otio.schema.Track(name=encoder_version)
+            )
 
-        # We need to copy the clip since there can only be one instance
-        # pr/timeline
-        # Add clip to track
-        if source_clip not in track:
-            track.append(deepcopy(source_clip))
+            # We need to copy the clip since there can only be one instance
+            # pr/timeline
+            # Add clip to track
+            if source_clip not in track:
+                track.append(deepcopy(source_clip))
 
     timeline.tracks.extend(track_map.values())
 

--- a/enctests/testframework/otio2html.py
+++ b/enctests/testframework/otio2html.py
@@ -2,6 +2,7 @@ import argparse
 from pathlib import Path
 import jinja2
 from testframework.main import *
+from .test_suite import TestSuite, SourceConfig
 from testframework.utils.outputTemplate import processTemplate, outputSummaryIndex
 # This code ideally ends up in main.py but may also make sense as a standalone.
 
@@ -57,7 +58,7 @@ def otio2htmlmain():
 
     test_configs = []
     if args.test_config_file:
-        test_configs.extend(TestSuite(Path(args.test_config_file)))
+        test_configs.append(TestSuite(Path(args.test_config_file)))
     else:
         test_configs.extend(
             get_configs(args, args.test_config_dir, ENCODE_TEST_SUFFIX)

--- a/enctests/testframework/otio2html.py
+++ b/enctests/testframework/otio2html.py
@@ -67,10 +67,15 @@ def otio2htmlmain():
     results = []
 
     for test_config in test_configs:
+        destination_folder = destination_from_config(
+            test_config,
+            args.results,
+            Path(args.results_folder)
+        )
         output_file = args.results
         if output_file == '':
             # We base it on the test filename
-            output_file = Path(args.results_folder) / f"{test_config.config_file().stem}.otio"
+            output_file = destination_folder / f"{test_config.config_file().stem}.otio"
             print("Outputfile:", output_file)
         else:
             output_file = Path(output_file)
@@ -81,14 +86,7 @@ def otio2htmlmain():
         
         first_test = test_config.tests()[0]
         
-        encoder = encoder_factory(
-            None,
-            first_test,
-            Path(args.encoded_folder),
-            test_config,
-            Path(args.results_folder)
-        )
-        test_config.set_destination(first_test.get("destination"))
+
 
         result = processTemplate(test_config, timeline)
         if result is not None:

--- a/enctests/testframework/templates/index.html.jinja
+++ b/enctests/testframework/templates/index.html.jinja
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Test Index</title>
+  <link rel="stylesheet" href="https://academysoftwarefoundation.github.io/EncodingGuidelines/assets/css/just-the-docs-default.css"> 
+  <script type="text/javascript" src="https://academysoftwarefoundation.github.io/EncodingGuidelines/assets/js/vendor/lunr.min.js"></script> 
+  <script type="text/javascript" src="https://academysoftwarefoundation.github.io/EncodingGuidelines/assets/js/just-the-docs.js"></script>
+</head>
+
+<body>
+
+
+<H1>ORI Encoding Test Report Index</H1>
+<table>
+<TR>
+<TH>Test</TH>
+<TH>Description</TH>
+<TH>Success</TH>
+<TH>Fail</TH>
+<TH>Started</TH>
+<TH>Duration</TH>
+</TR>
+
+{% for report in results|sort(attribute='title') %}
+<TR>
+<TD><A href="{{ report.relativeurl }}">{{report.title}}</a></TD>
+<TD>{{report.description}}</TD>
+<TD align=right>{{report.success_tests}}</TD>
+<TD align=right>{{report.error_tests}}</TD>
+<TD >{{report.test_start}}</TD>
+<TD align=right>{{"%.2f"|format(report.test_duration) }}</TD>
+
+</TR>
+  {% endfor %}
+</TABLE>
+</body>
+</html>

--- a/enctests/testframework/test_suite.py
+++ b/enctests/testframework/test_suite.py
@@ -1,0 +1,179 @@
+import os
+import sys
+import time
+import shlex
+import yaml
+import pathlib
+from copy import deepcopy
+from typing import Any
+
+try:
+    from yaml import CSafeLoader as SafeLoader
+    from yaml import CSafeDumper as SafeDumper
+
+except ImportError:
+    from yaml import SafeLoader, SafeDumper
+
+"""
+A test of classes to help manage loading and querying the test suites and the associated source content.
+"""
+
+# Test config files
+from .utils import (
+    create_clip,
+    get_media_info,
+    get_source_path,
+    get_nearest_model,
+    get_test_metadata_dict,
+    get_source_metadata_dict
+)
+
+
+class BaseYamlConfig:
+    """
+    Base class for reading the yaml file in, and storing the location of the file.
+    """
+    def __init__(self,
+                 test_config_file: pathlib.Path):
+        self.__config__ = {}
+        self.parse_config_file(test_config_file)
+
+    def dictcopy(self):
+        return deepcopy(self.__config__)
+
+    def parse_config_file(self, path: pathlib.Path):
+        self.__config_path = path
+        path = path.absolute().as_posix()
+        self.__config__ = {}
+        with open(path, 'rt') as f:
+            self.__config__ = list(yaml.load_all(f, SafeLoader))
+        return self.__config__
+    
+    def config_file(self):
+        """Return the path to the config file that was read in."""
+        return self.__config_path
+
+            
+    def __getattr__(self, __name: str) -> Any:
+        return self.__config__[__name]
+
+    def get(self, key, default=None):
+        return self.__getattr__(key)
+
+class SourceConfig(BaseYamlConfig):
+    """
+    Used for storing the data structure of the source config file.
+    This is a little different to the BaseYamlConfig, since we assume the parameters are all on the
+    top level of the yaml file.
+    """
+    def __init__(self,
+                 test_config_file: pathlib.Path):
+        super(SourceConfig, self).__init__(test_config_file)
+
+    def parse_config_file(self, path: pathlib.Path):
+        self.__config__ = super(SourceConfig, self).parse_config_file(path)[0]
+
+    def path(self):
+        """Get the path to the imagery"""
+        p = pathlib.Path(self.__config__["path"])
+        if not p.is_absolute():
+            p = self.config_file().parent.joinpath(p).resolve()
+        return p
+            
+    def __getattr__(self, __name: str) -> Any:
+        if __name == "path":
+            return self.path()
+        return self.__config__[__name]
+    
+class TestConfig:
+    """
+    This is tracking an individual test within a config file.
+    There could be still be multiple wedges within this test config.
+    """
+    def __init__(self, test_name: str, test_dict: dict, test_config: str):
+        self.__name = test_name
+        self.__config_path = test_config
+        self.__test_dict = test_dict
+    
+    def sources(self):
+        sources = self.__test_dict.get('sources', [])
+        return [SourceConfig(pathlib.Path(path)) for path in sources]
+    
+    def __getattr__(self, __name: str) -> Any:
+        return self.__test_dict[__name]
+    
+    def get(self, key, default=None):
+        try:
+            return self.__getattr__(key)
+        except KeyError:
+            return default
+    
+    def set_destination(self, destination: pathlib.Path):
+        """Record where we are writing out the test results to."""
+        self.__test_dict['destination'] = destination
+
+    def config_file(self):
+        return self.__config_path
+    
+class TestSuite(BaseYamlConfig):
+    """
+    This is the main testSuite config.
+    """
+    def __init__(self,
+                 test_config_file: pathlib.Path):
+        self.test_configs = []
+        self.__report = None
+        self._tests = None
+        self.__destination = None
+        self.__config__ = {}
+        super(TestSuite, self).__init__(test_config_file)
+
+    def parse_config_file(self, path: pathlib.Path):
+        config = super(TestSuite, self).parse_config_file(path)
+
+        test_configs = []
+        report = None
+        for test_dict in config:
+            for test_name, test_config in test_dict.items():
+                # Store path to config file for future reference.
+                #test_name = next(iter(test_config))
+                #print("TEST NAME:", test_name, test_config)
+                if test_name == "reports":
+                    report = test_config
+                    continue
+                if test_name.startswith('test_'):
+                    # Only store config path for tests
+                    test_config['test'] = test_name # TODO Should we warn if it exists, and isnt this?
+                    test_config['test_config_path'] = self.config_file()
+                    tst = TestConfig(test_name, test_config, self.config_file())
+                    test_configs.append(tst)
+                else:
+                    print(f"Unattached param:{test_name} = {test_config}")
+                    self.__config__[test_name] = test_config
+    
+        self.__tests = test_configs
+        self.__report = report
+    
+    def tests(self):
+        return self.__tests
+
+    def sources(self):
+        """Return all the sources in this testSuite"""
+        sources = [tst.sources() for tst in self.test_configs]
+        return sources
+    
+    def report(self):
+        return self.__report
+
+    def __getattr__(self, __name: str) -> Any:
+        if __name == "path":
+            return self.path()
+        if __name == "destination":
+            return self.__destination
+        if __name == "app":
+            # We are going to grab the app from the first test
+            return self.tests()[0].get("app")
+        return self.__config__[__name]
+    
+    def set_destination(self, destination: pathlib.Path):
+        self.__destination = destination

--- a/enctests/testframework/utils/outputTemplate.py
+++ b/enctests/testframework/utils/outputTemplate.py
@@ -8,8 +8,9 @@ import opentimelineio as otio
 import pandas as pd
 import jinja2
 from pathlib import Path
+from ..test_suite import TestSuite, SourceConfig
 
-def _exportGraph(reportconfig, graph, alltests):
+def _exportGraph(config, reportconfig, graph, alltests):
   """
   Export a graph using all the test data.
   :param reportconfig: The report configuration to output. 
@@ -35,7 +36,7 @@ def _exportGraph(reportconfig, graph, alltests):
 
   filename = reportconfig['name']+"-"+graph.get("name")
   if "directory" in reportconfig:
-    filename = os.path.join(reportconfig['directory'], filename)
+    filename = os.path.join(config.get('destination'), filename)
   if os.path.exists(filename):
     # Running inside docker sometimes doesnt let you write over files. 
     os.remove(filename)
@@ -45,23 +46,19 @@ def _exportGraph(reportconfig, graph, alltests):
 
 
 
-def processTemplate(test_configs, otio_info):
+def processTemplate(config, timeline):
   """
   Look for any report configs in the test_configurations and apply them to the specified otio file.
   :param test_configs: a list of test configurations.
   :param otio_info: A otio object containing the test results.
   """
 
-  reportconfig = None
-  for config in test_configs:
-    if "reports" in config:
-      reportconfig = config['reports']
-    
+  reportconfig = config.report()
   if reportconfig is None:
     print("Failed to find report config. Skipping html export.")
-    exit(0)
+    return
 
-  tracks = otio_info.tracks[0]
+  tracks = timeline.tracks[0]
   testinfo = {'ffmpeg_version': tracks.name.replace("ffmpeg_version_", "")}
 
   tests = {}
@@ -76,6 +73,7 @@ def processTemplate(test_configs, otio_info):
               continue
           merge_test_info = test_info.metadata['aswf_enctests']['results']
           merge_test_info['name'] = ref_name
+          merge_test_info['wedge'] = ref_name.replace(track.metadata.get('source_test_name', '')+"-", "")
           if 'description' in test_info.metadata['aswf_enctests']:
             merge_test_info['test_description'] = test_info.metadata['aswf_enctests']['description']
           results.append(merge_test_info)
@@ -109,14 +107,14 @@ def processTemplate(test_configs, otio_info):
         tests[track.name] = {'results': results, 'source_info': track.metadata['aswf_enctests']['source_info'], 'default_media': default_media}
 
   for graph in reportconfig.get("graphs", []):
-    _exportGraph(reportconfig, graph, alltests)
+    _exportGraph(config, reportconfig, graph, alltests)
 
   environment = jinja2.Environment(loader=jinja2.FileSystemLoader("testframework/templates/"))
 
   template = environment.get_template(reportconfig['templatefile'])
   htmlreport = reportconfig['name']+".html"
-  if "directory" in reportconfig:
-    htmlreport = os.path.join(reportconfig['directory'], htmlreport)
+  #if "directory" in reportconfig:
+  htmlreport = os.path.join(config.get('destination'), htmlreport)
   if os.path.exists(htmlreport):
     # Running inside docker sometimes doesnt let you write over files.
     os.remove(htmlreport)
@@ -124,4 +122,53 @@ def processTemplate(test_configs, otio_info):
   f.write(template.render(tests=tests, testinfo=testinfo, config=reportconfig))
   f.close()
   print("Written out:", htmlreport)
+  return {'reporturl': htmlreport, 'tests': tests, 'testinfo': testinfo, 'config': reportconfig}
 
+def outputSummaryIndex(output_dir):
+    """
+    Create a summary index of all the test results in the specified folder.
+    :param output folder.
+    """
+
+    test_results = []
+    for root, dirs, files in os.walk(output_dir):
+        for filename in files:
+            if filename.endswith(".otio"):
+                path = Path(root) / filename
+                timeline = otio.adapters.read_from_file(path.as_posix())
+                # Now we need to figure out the config file.
+                tracks = timeline.tracks[0]
+
+                configfile = timeline.metadata['config_file']
+
+                #Load the test 
+                testsuite = TestSuite(Path(configfile))
+                reportconfig = testsuite.report()
+                htmlreport = path.parent / (reportconfig['name']+".html")
+                results = {'title': reportconfig["title"],
+                           'description': reportconfig['description'],
+                           'relativeurl': htmlreport.relative_to(output_dir),
+                           'error_tests': 0,
+                           'success_tests': 0,
+                           'test_start': timeline.metadata.get("test_start", "unknown"),
+                           'platform': timeline.metadata.get("platform", "unknown"),
+                           'test_duration': timeline.metadata.get("test_duration", "unknown")
+                           }
+                for track in tracks:
+                  for ref_name, test_info in track.media_references().items():
+                    if ref_name == "DEFAULT_MEDIA":
+                       continue
+                    merge_test_info = test_info.metadata['aswf_enctests']['results']
+                    if merge_test_info['success']:
+                       results['success_tests'] += 1
+                    else:
+                       results['error_tests'] += 1
+                test_results.append(results)
+
+    environment = jinja2.Environment(loader=jinja2.FileSystemLoader("testframework/templates/"))
+
+    template = environment.get_template('index.html.jinja')
+    htmlreport = Path(output_dir) / "index.html"
+    f = open(htmlreport, "w")
+    f.write(template.render(results=test_results))
+    f.close()

--- a/enctests/testframework/utils/outputTemplate.py
+++ b/enctests/testframework/utils/outputTemplate.py
@@ -144,6 +144,8 @@ def outputSummaryIndex(output_dir):
                 #Load the test 
                 testsuite = TestSuite(Path(configfile))
                 reportconfig = testsuite.report()
+                if reportconfig is None:
+                   continue
                 htmlreport = path.parent / (reportconfig['name']+".html")
                 results = {'title': reportconfig["title"],
                            'description': reportconfig['description'],
@@ -159,7 +161,7 @@ def outputSummaryIndex(output_dir):
                     if ref_name == "DEFAULT_MEDIA":
                        continue
                     merge_test_info = test_info.metadata['aswf_enctests']['results']
-                    if merge_test_info['success']:
+                    if merge_test_info.get('success', True):
                        results['success_tests'] += 1
                     else:
                        results['error_tests'] += 1

--- a/enctests/testframework/utils/utils.py
+++ b/enctests/testframework/utils/utils.py
@@ -2,7 +2,6 @@ import os
 import json
 import shlex
 import pyseq
-from copy import deepcopy
 from pathlib import Path
 from subprocess import run, CalledProcessError
 
@@ -164,14 +163,10 @@ def get_source_metadata_dict(source_clip):
 
 
 def create_clip(config):
-    path = Path(config.get('path'))
-    if not path.is_absolute():
-        if 'config_path' in config:
-            config_path = Path(config.get('config_path'))
-            path = config_path.parent.joinpath(path).resolve()
+    path = config.path()
 
     clip = otio.schema.Clip(name=path.stem)
-    clip.metadata.update({'aswf_enctests': {'source_info': deepcopy(config)}})
+    clip.metadata.update({'aswf_enctests': {'source_info': config.dictcopy()}})
 
     # Source range
     clip.source_range = get_source_range(config)

--- a/enctests/testframework/utils/utils.py
+++ b/enctests/testframework/utils/utils.py
@@ -43,7 +43,7 @@ def get_nearest_model(width):
     }
     diff = lambda list_value: abs(list_value - width)
 
-    return models[min(models, key=diff)]
+    return models[min(models, key=diff)].as_posix()
 
 
 def get_media_info(path, startframe=None):


### PR DESCRIPTION
This is a fairly large change, to pre-define where the results go by default. You can still override them, but by default we are making a directory structure based on ffmpeg version and platform.

This also allows us to simply run python3 -m testframework.main to run all the tests in test_config. The test_config folder should get re-organised so that it truely is just ffmpeg tests, rather than some of the wedge tests that we also have in there.

Lastly, we make an index.html page in the top level results page, which is a brief summary of all the otio tests in that folder structure, to aid navigation.