### PR TITLE
VMAF Environment variables

### DIFF
--- a/enctests/testframework/main.py
+++ b/enctests/testframework/main.py
@@ -43,13 +43,13 @@ IDIFF_BIN = os.getenv(
 )
 
 
-VMAF_LIB_DIR = os.getenv(
-    'VMAF_LIB_DIR',
-    f'{os.path.dirname(__file__)}/../.venv/usr/local/lib/x86_64-linux-gnu'
+VMAF_MODEL_DIR = os.getenv(
+    'VMAF_MODEL_DIR',
+    '/usr/share/vmaf'
 )
 
-if not Path(VMAF_LIB_DIR, "model", "vmaf_v0.6.1.json").exists():
-    print(f"WARNING: Cannot find VMAF configuration files at path {VMAF_LIB_DIR}")
+if not Path(VMAF_MODEL_DIR, "vmaf_v0.6.1.json").exists():
+    print(f"WARNING: Cannot find VMAF configuration files at path {VMAF_MODEL_DIR}")
 
 def parse_args():
     parser = argparse.ArgumentParser()
@@ -302,11 +302,11 @@ model=path={vmaf_model}\" \
     log_file_object.flush() # Need to flush it to make sure its before the subprocess logging.
 
     env = os.environ
-    if 'LD_LIBRARY_PATH' in env:
-        env['LD_LIBRARY_PATH'] += f'{os.pathsep}{VMAF_LIB_DIR}'
+    # if 'LD_LIBRARY_PATH' in env:
+    #     env['LD_LIBRARY_PATH'] += f'{os.pathsep}{VMAF_LIB_DIR}'
 
-    else:
-        env.update({'LD_LIBRARY_PATH': VMAF_LIB_DIR})
+    # else:
+    #     env.update({'LD_LIBRARY_PATH': VMAF_LIB_DIR})
 
     compare_log = Path("compare_log.json")
     if compare_log.exists():

--- a/enctests/testframework/main.py
+++ b/enctests/testframework/main.py
@@ -49,7 +49,8 @@ VMAF_MODEL_DIR = os.getenv(
 )
 
 if not Path(VMAF_MODEL_DIR, "vmaf_v0.6.1.json").exists():
-    print(f"WARNING: Cannot find VMAF configuration files at path {VMAF_MODEL_DIR}")
+    print(f"WARNING: Cannot find VMAF configuration files at path {VMAF_MODEL_DIR}, this is defined by the environment variable VMAF_MODEL_DIR.")
+    exit(1)
 
 def parse_args():
     parser = argparse.ArgumentParser()

--- a/enctests/testframework/main.py
+++ b/enctests/testframework/main.py
@@ -303,12 +303,6 @@ model=path={vmaf_model}\" \
     log_file_object.flush() # Need to flush it to make sure its before the subprocess logging.
 
     env = os.environ
-    # if 'LD_LIBRARY_PATH' in env:
-    #     env['LD_LIBRARY_PATH'] += f'{os.pathsep}{VMAF_LIB_DIR}'
-
-    # else:
-    #     env.update({'LD_LIBRARY_PATH': VMAF_LIB_DIR})
-
     compare_log = Path("compare_log.json")
     if compare_log.exists():
         # Make sure we remove the old one, so that we know one is generated.

--- a/enctests/testframework/utils/utils.py
+++ b/enctests/testframework/utils/utils.py
@@ -7,16 +7,16 @@ from subprocess import run, CalledProcessError
 
 import opentimelineio as otio
 
-VMAF_LIB_DIR = os.getenv(
-    'VMAF_LIB_DIR',
-    f'{os.path.dirname(__file__)}/.venv/usr/local/lib/x86_64-linux-gnu'
+VMAF_MODEL_DIR = os.getenv(
+    'VMAF_MODEL_DIR',
+    '/usr/share/vmaf'
 )
 
 # Which vmaf model to use
-VMAF_HD_MODEL = Path(VMAF_LIB_DIR, "model", "vmaf_v0.6.1.json")
+VMAF_HD_MODEL = Path(VMAF_MODEL_DIR, "vmaf_v0.6.1.json")
 
 
-VMAF_4K_MODEL = Path(VMAF_LIB_DIR, "model", "vmaf_4k_v0.6.1.json")
+VMAF_4K_MODEL = Path(VMAF_MODEL_DIR, "vmaf_4k_v0.6.1.json")
 
 
 # Based on accepted answer here:


### PR DESCRIPTION
On the different platforms, its easier to just assume the VMAF model …directory exists somewhere

rather than the whole lib directory. So we have changed the environment variable to be VMAF_MODEL_DIR rather than the VMAF_LIB_DIR we had before.