### PR TITLE
Explicitly adding a wedge field, to make it easy to display in graphs.

### DIFF
--- a/enctests/testframework/encoders/ffmpeg_encoder.py
+++ b/enctests/testframework/encoders/ffmpeg_encoder.py
@@ -99,6 +99,8 @@ class FFmpegEncoder(ABCTestEncoder):
                 'test_config_path'
             ))
             test_meta['command'] = cmd
+            test_meta['wedge_name'] = wedge_name
+            test_meta['test_prefix'] = self.test_config.get('name')
             test_meta['encode_arguments'] = wedge
             test_meta['description'] = self.test_config.get('description')
             test_meta['outputfile'] = str(out_file)

--- a/enctests/testframework/utils/outputTemplate.py
+++ b/enctests/testframework/utils/outputTemplate.py
@@ -73,7 +73,8 @@ def processTemplate(config, timeline):
           merge_test_info = test_info.metadata['aswf_enctests']['results']
           merge_test_info['name'] = ref_name
           merge_test_info['testbasename'] = test_info.metadata['aswf_enctests']['testbasename']
-          merge_test_info['wedge'] = ref_name.replace(track.metadata.get('source_test_name', '')+"-", "")
+          merge_test_info['wedge'] = test_info.metadata['aswf_enctests']['wedge_name']
+          print("Wedge:", merge_test_info['wedge'], ref_name)
           if 'description' in test_info.metadata['aswf_enctests']:
             merge_test_info['test_description'] = test_info.metadata['aswf_enctests']['description']
           results.append(merge_test_info)


### PR DESCRIPTION
Make sure there is a parameter that is only the wedge value, rather than concatenating the test and the wedge, it makes some of the graphs a little easier to read.