### PR TITLE
Add Houdini to AV1 and VP9 documents

### DIFF
--- a/EncodeAv1.md
+++ b/EncodeAv1.md
@@ -20,7 +20,7 @@ AV1 has browser support in:
    * Opera
 the main missing one is Safari. Apple has now joined the AOM group, and we are starting to see AV1 hardware support in their latest hardware, but currently safari does still not support it.
 
-Outside of the web browser, AV1 support is pretty much limited to ffmpeg and VLC.
+Outside of the web browser, AV1 support is pretty much limited to Houdini, ffmpeg and VLC.
 
 AV1 is supported by mp4 and webm containers, no support exists for mov.
 

--- a/EncodeVP9.md
+++ b/EncodeVP9.md
@@ -20,7 +20,7 @@ VP9 has browser support in:
 
 VP9 is supported by mp4 and webm containers, no support exists for mov.
 
-Outside of the web browser, VP9 support is pretty much limited to Davinci Resolve, Blender, ffmpeg and VLC.
+Outside of the web browser, VP9 support is pretty much limited to Davinci Resolve, Houdini, Blender, ffmpeg and VLC.
 
 The two codecs we will cover are:
 * [libvpx-vp9](#libvpx-vp9)


### PR DESCRIPTION
Houdini 20.0 adds support for AV1 and VP9 encoding/decoding, amongst others.